### PR TITLE
Fix responsive layout for mobile and small screens

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -21,6 +21,14 @@ h1 {
     h1 {
         font-size: 3rem;
     }
+
+    p {
+        font-size: 1rem;
+    }
+
+    h2 {
+        font-size: 2rem;
+    }
 }
 
 h1, .subtitle, .bio, .cta-buttons {
@@ -459,7 +467,6 @@ h1, .subtitle, .bio, .cta-buttons {
 }
 
 button {
-    margin-top: 20px;
     padding: 10px 20px;
     background-color: #00ffff;
     color: #0a192f;
@@ -710,6 +717,10 @@ p {
 }
 
 @media (max-width: 768px) {
+    .expertise-section h2 {
+        font-size: 2rem;
+    }
+
     .expertise-grid {
         flex-direction: column;
         align-items: center;
@@ -1179,16 +1190,43 @@ p {
 /* Estilos responsivos */
 @media (max-width: 768px) {
     .home-content {
-        flex-direction: column; /* Cambia a columna en pantallas pequeñas */
+        flex-direction: column;
         align-items: center;
     }
 
+    .home-text {
+        padding-right: 0;
+        text-align: center;
+        width: 100%;
+    }
+
     .home-image {
-        display: block; /* Cambia de 'none' a 'block' */
+        display: block;
     }
 
     .profile-image {
-        width: 40%; /* Ajusta el tamaño según sea necesario */
+        width: 65%;
+    }
+
+    .subtitle {
+        font-size: 1.3rem;
+        letter-spacing: 0.04em;
+    }
+
+    .cta-buttons {
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 14px;
+    }
+
+    .cta-button {
+        font-size: 0.95rem;
+        padding: 10px 22px;
+    }
+
+    .tech-icons {
+        flex-wrap: wrap;
+        gap: 16px;
     }
 }
 
@@ -1344,13 +1382,28 @@ p {
 
 /* Ajustes responsivos */
 @media (max-width: 768px) {
+    .contact-section h2 {
+        font-size: 2rem;
+    }
+
+    .contact-section p {
+        font-size: 1.1rem;
+        margin-bottom: 30px;
+    }
+
     .contact-container {
-        flex-direction: column; /* Cambiar el layout a columna en móviles */
+        flex-direction: column;
     }
 
     .contact-card {
-        flex-basis: 100%; /* Ocupa el 100% del ancho en móviles */
-        margin-bottom: 20px; /* Añadir margen entre los cards en móviles */
+        flex-basis: 100%;
+        margin-bottom: 20px;
+    }
+
+    .send-message-button {
+        width: 100%;
+        padding: 14px;
+        font-size: 1rem;
     }
 }
 
@@ -1596,9 +1649,17 @@ p {
 
 /* Responsividad para pantallas más pequeñas */
 @media (max-width: 768px) {
+    .experience-section h2 {
+        font-size: 2rem;
+    }
+
     .timeline {
         width: 100%;
         padding: 0 10px;
+    }
+
+    .timeline-item {
+        margin-top: 50px;
     }
 
     .timeline-content ul li {
@@ -1606,8 +1667,9 @@ p {
     }
 
     .timeline-date {
-        font-size: 1rem;
+        font-size: 0.9rem;
         padding: 5px 10px;
+        white-space: nowrap;
     }
 
     .timeline-content {
@@ -1676,6 +1738,72 @@ p {
     background: rgba(0, 255, 255, 0.05);
     text-align: center;
     margin: 20px 0 0;
+}
+
+/* ===========================
+   Extra small screens (≤480px)
+   =========================== */
+@media (max-width: 480px) {
+    h1 {
+        font-size: 2.2rem;
+    }
+
+    .subtitle {
+        font-size: 1rem;
+        letter-spacing: 0.02em;
+    }
+
+    .bio {
+        font-size: 0.95rem;
+    }
+
+    .profile-image {
+        width: 78%;
+    }
+
+    .tech-icons svg {
+        font-size: 1.5rem;
+    }
+
+    .cta-button {
+        font-size: 0.85rem;
+        padding: 10px 18px;
+    }
+
+    .expertise-section h2,
+    .experience-section h2,
+    .projects-section h2,
+    .contact-section h2 {
+        font-size: 1.8rem;
+    }
+
+    .projects-subtitle {
+        font-size: 0.95rem;
+    }
+
+    .project-card {
+        padding: 20px;
+    }
+
+    .contact-details,
+    .contact-form {
+        padding: 24px 20px;
+    }
+
+    .timeline-content {
+        padding: 12px;
+    }
+
+    .timeline-content h3 {
+        font-size: 1.3rem;
+    }
+
+    .scroll-to-top {
+        bottom: 16px;
+        right: 16px;
+        width: 40px;
+        height: 40px;
+    }
 }
 
 /* --------------


### PR DESCRIPTION
- Override global p (1.5vw) and h2 (4vw) with fixed sizes at ≤768px
- Fix profile-image width from 40% to 65% in column layout
- Add flex-wrap to cta-buttons to prevent overflow on narrow screens
- Add subtitle, home-text and tech-icons mobile overrides
- Add h2 mobile overrides for expertise, experience and contact sections
- Add send-message-button full-width on mobile
- Add margin-top on timeline-item to prevent date label overlap
- Add 480px breakpoint for extra-small screens
- Remove global button margin-top that interfered with filter-btn